### PR TITLE
Use 'ARG' statement for setting 'DEBIAN_FRONTEND=noninteractive'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM ubuntu:latest
+
+ARG DEBIAN_FRONTEND=noninteractive
 ENV NYXTVERSION=2.2.4
+
 WORKDIR /opt/nyxt
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+
+RUN apt-get update && \
+    apt-get install -yq \
     wget \
     libfixposix-dev \
     libwebkit2gtk-4.0-dev \


### PR DESCRIPTION
Setting it via `ARG` makes it available during all the build (eg. the `dpkg` invocation).
Also, the variable is not set at container run time (only during build).
Maybe `NYXTVERSION` could use the same?